### PR TITLE
Add PDF upload feature with size limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 streamlit>=1.20.0
 openai>=0.28.0
 faiss-cpu>=1.7.4
+PyPDF2>=3.0


### PR DESCRIPTION
## Summary
- enable reading PDF uploads directly in `mentor_app.py`
- track the last uploaded file in session state
- enforce a 1MB upload size limit
- update requirements for PyPDF2

## Testing
- `python -m py_compile mentor_app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_6889100878c48329ac09fbc7668091ec