### PR TITLE
Enhance chat UI with larger text and repositioned input

### DIFF
--- a/mentor_app.py
+++ b/mentor_app.py
@@ -20,6 +20,22 @@ def load_agenda(meeting_name: str) -> list[dict] | None:
 # ---------- PAGE SETUP ----------
 st.set_page_config(page_title="Mashauri AI Mentor", layout="centered")
 
+# ---------- STYLING ----------
+st.markdown(
+    """
+    <style>
+    /* Increase default font size for readability */
+    div[data-testid="stChatMessage"] p, .stMarkdown p {
+        font-size: 1.1rem;
+    }
+    textarea, input {
+        font-size: 1.1rem !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # ---------- HEADER ----------
 col1, col2, col3 = st.columns([1, 6, 1])
 with col1:
@@ -142,9 +158,14 @@ if st.session_state.state == "awaiting_agenda_prompt" and agenda:
     st.rerun()
 
 # ---------- USER INPUT ----------
-user_input = st.chat_input("Your message here...")
-if user_input:
+if "user_input" not in st.session_state:
+    st.session_state.user_input = ""
+
+user_input = st.text_area("Your message here...", key="user_input", height=100)
+send_clicked = st.button("Send")
+if send_clicked and user_input:
     response = user_input.strip()
+    st.session_state.user_input = ""
     add_user_message(response)
 
     is_first = st.session_state.step == 0

--- a/mentor_app.py
+++ b/mentor_app.py
@@ -158,15 +158,26 @@ if st.session_state.state == "awaiting_agenda_prompt" and agenda:
     st.rerun()
 
 # ---------- USER INPUT ----------
+# Track the contents of the text area in session state.
 if "user_input" not in st.session_state:
     st.session_state.user_input = ""
+
+# Flag to clear the input box on the next run. We set a flag instead of
+# modifying `st.session_state.user_input` directly after the widget is
+# instantiated, which Streamlit disallows outside the widget's own callback.
+if "clear_input" not in st.session_state:
+    st.session_state.clear_input = False
+if st.session_state.clear_input:
+    st.session_state.user_input = ""
+    st.session_state.clear_input = False
 
 def handle_send():
     response = st.session_state.user_input.strip()
     if not response:
         return
-    st.session_state.user_input = ""
     add_user_message(response)
+    # Mark that the text area should be cleared before the next render
+    st.session_state.clear_input = True
 
     is_first = st.session_state.step == 0
     mt = st.session_state.get("meeting_type", "")

--- a/mentor_app.py
+++ b/mentor_app.py
@@ -161,10 +161,10 @@ if st.session_state.state == "awaiting_agenda_prompt" and agenda:
 if "user_input" not in st.session_state:
     st.session_state.user_input = ""
 
-user_input = st.text_area("Your message here...", key="user_input", height=100)
-send_clicked = st.button("Send")
-if send_clicked and user_input:
-    response = user_input.strip()
+def handle_send():
+    response = st.session_state.user_input.strip()
+    if not response:
+        return
     st.session_state.user_input = ""
     add_user_message(response)
 
@@ -258,3 +258,7 @@ if send_clicked and user_input:
             "This meeting is finished! You can review the chat above or close the page\n\n "
             "Please complete the post meeting Google form https://docs.google.com/forms/d/e/1FAIpQLSc0QN87pDYQVamKVpYtUQyfO9qPq0CWrMjc5-kqLMZ4HawILg/viewform?usp=preview"
         )
+    st.rerun()
+
+st.text_area("Your message here...", key="user_input", height=100)
+st.button("Send", on_click=handle_send)


### PR DESCRIPTION
## Summary
- Enlarge default text and input fonts for better readability
- Replace bottom-fixed chat input with a text area and send button displayed beneath the chat history

## Testing
- `python -m py_compile mentor_app.py`


------
https://chatgpt.com/codex/tasks/task_b_689f1004739c8329bd1c2e2f7aa2d2e8