### PR TITLE
Add M4A transcription helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,27 @@ Make sure `data/` is git-ignored and, in production (e.g. on Render), set:
 ```bash
 render env set CHAT_HISTORY_DIR=/mnt/data/chat_history
 
+
+## Transcribing M4A files with Whisper
+
+Follow these steps to turn an M4A audio file into text using the `transcribe_m4a.py` helper:
+
+1. **Install Python packages** (from this project root):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Add your OpenAI key** to the terminal environment (replace the placeholder with your key):
+   ```bash
+   export OPENAI_API_KEY=your_real_api_key_here
+   ```
+3. **Run the script** with your M4A path and where you want the transcript saved:
+   ```bash
+   python transcribe_m4a.py --input /full/path/to/audio.m4a --output /full/path/to/transcript.txt
+   ```
+   - If you skip `--output`, the text will simply print in the terminal.
+4. *(Optional)* Tweak accuracy or language:
+   - `--model` chooses a Whisper model (default: `whisper-1`).
+   - `--prompt` supplies extra context for the model.
+   - `--language` hints the spoken language (for example, `en` for English or `es` for Spanish).
+
+That’s it—once the command finishes, open the `transcript.txt` file (or the printed output) to read the text version of your audio file.

--- a/transcribe_m4a.py
+++ b/transcribe_m4a.py
@@ -1,0 +1,107 @@
+"""CLI utility to transcribe M4A audio files with Whisper.
+
+Usage:
+    python transcribe_m4a.py --input path/to/audio.m4a --output transcript.txt
+
+Requires the OPENAI_API_KEY environment variable to be set.
+"""
+
+import argparse
+import os
+from pathlib import Path
+from typing import Optional
+
+from openai import OpenAI
+
+
+def transcribe_m4a(
+    input_path: Path,
+    output_path: Optional[Path] = None,
+    model: str = "whisper-1",
+    prompt: Optional[str] = None,
+    language: Optional[str] = None,
+) -> str:
+    """Transcribe an M4A file using the Whisper API.
+
+    Args:
+        input_path: Path to the M4A audio file.
+        output_path: Optional path where the transcript will be written.
+        model: Whisper model to use.
+        prompt: Optional prompt to guide the transcription.
+        language: Optional language code (e.g., "en") to hint the model.
+
+    Returns:
+        The transcribed text.
+    """
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError(
+            "OPENAI_API_KEY is not set. Please export your API key before running the script."
+        )
+
+    client = OpenAI(api_key=api_key)
+
+    with input_path.open("rb") as audio_file:
+        response = client.audio.transcriptions.create(
+            model=model,
+            file=audio_file,
+            prompt=prompt,
+            language=language,
+        )
+
+    transcript = response.text
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(transcript, encoding="utf-8")
+
+    return transcript
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Transcribe an M4A file with Whisper.")
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to the M4A audio file to transcribe.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output path for the transcript (text file).",
+    )
+    parser.add_argument(
+        "--model",
+        default="whisper-1",
+        help="Whisper model to use (default: whisper-1).",
+    )
+    parser.add_argument(
+        "--prompt",
+        help="Optional prompt to provide context to the model.",
+    )
+    parser.add_argument(
+        "--language",
+        help="Optional language code (e.g., en, es) to guide transcription.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    transcript = transcribe_m4a(
+        input_path=args.input,
+        output_path=args.output,
+        model=args.model,
+        prompt=args.prompt,
+        language=args.language,
+    )
+    print(transcript)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rename the Whisper helper to `transcribe_m4a.py` and update messaging for M4A audio transcription
- keep the same CLI options while retargeting the script toward M4A files
- refresh README instructions to explain running the helper on M4A audio

## Testing
- python -m compileall transcribe_m4a.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693adf5e5b108329a84a87c546715c23)